### PR TITLE
Use tox on Jenkins to run against multiple Python versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ properties([[
   ]
 ]]);
 
-
 pipeline_builder = new PipelineBuilder(this, container_build_nodes)
 pipeline_builder.activateEmailFailureNotifications()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
+      export PATH=/home/jenkins/miniconda/envs/env/bin:$PATH
       cd ${project}
       python -m tox -- --junitxml=${test_output}
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,19 +40,16 @@ builders = pipeline_builder.createBuilders { container ->
       export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
       python --version
-      /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements.txt
-      /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements-dev.txt
+      python -m pip install --user -r ${project}/requirements.txt
+      python -m pip install --user -r ${project}/requirements-dev.txt
     """
   } // stage
 
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
-      /opt/miniconda/bin/conda init bash
-      export PYTHONPATH=
-      export PATH=/opt/miniconda/bin:$PATH
       cd ${project}
-      /opt/miniconda/bin/python -m tox -- --junitxml=${test_output}
+      python -m tox -- --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,11 +44,13 @@ builders = pipeline_builder.createBuilders { container ->
       /home/jenkins/miniconda/bin/conda init bash
       /home/jenkins/miniconda/bin/conda create -n env python=${python_version}
       echo "/home/nicos/miniconda/bin/conda activate env" >> ~/.bashrc
+      export PYTHONPATH=
     """
   } // stage
 
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
+      export PATH=/home/jenkins/miniconda/envs/env/bin:$PATH
       python --version
       python -m pip install --user -r ${project}/requirements.txt
       python -m pip install --user -r ${project}/requirements-dev.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,9 @@ builders = pipeline_builder.createBuilders { container ->
     container.sh """
       export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
-      python --version
-      python -m pip install --user -r ${project}/requirements.txt
-      python -m pip install --user -r ${project}/requirements-dev.txt
+      /opt/miniconda/bin/python --version
+      /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements.txt
+      /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements-dev.txt
     """
   } // stage
 
@@ -51,7 +51,7 @@ builders = pipeline_builder.createBuilders { container ->
       export PYTHONPATH=
       export PATH=/home/jenkins/miniconda/bin:$PATH
       cd ${project}
-      python -m tox -- --junitxml=${test_output}
+      /opt/miniconda/bin/python -m tox -- --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ builders = pipeline_builder.createBuilders { container ->
     container.sh """
       curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
       sh miniconda.sh -b -p miniconda
+      miniconda/bin/conda init bash
       miniconda/bin/conda create -n env python=${python_version}
       miniconda/bin/conda activate env
       python --version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ import ecdcpipeline.PipelineBuilder
 
 project = "python-streaming-data-types"
 
-python_version = "3.7"
+python_version = "3.8"
 
 container_build_nodes = [
   'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ builders = pipeline_builder.createBuilders { container ->
       /opt/miniconda/bin/conda init bash
       export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
-      bin/python --version
+      python --version
       /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements.txt
       /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements-dev.txt
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ builders = pipeline_builder.createBuilders { container ->
     container.sh """
       /opt/miniconda/bin/conda init bash
       export PYTHONPATH=
-      export PATH=/home/jenkins/miniconda/bin:$PATH
+      export PATH=/opt/miniconda/bin:$PATH
       cd ${project}
       /opt/miniconda/bin/python -m tox -- --junitxml=${test_output}
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,20 +35,10 @@ builders = pipeline_builder.createBuilders { container ->
     container.copyTo(pipeline_builder.project, pipeline_builder.project)
   }  // stage
 
-  pipeline_builder.stage("${container.key}: Conda") {
-    container.sh """
-      curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-      sh miniconda.sh -b -p /home/jenkins/miniconda
-      /home/jenkins/miniconda/bin/conda update -n base -c defaults conda -y
-      /home/jenkins/miniconda/bin/conda init bash
-      export PYTHONPATH=
-    """
-  } // stage
-
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
       export PYTHONPATH=
-      export PATH=/home/jenkins/miniconda/bin:$PATH
+      export PATH=/opt/miniconda/bin:$PATH
       python --version
       python -m pip install --user -r ${project}/requirements.txt
       python -m pip install --user -r ${project}/requirements-dev.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@ import ecdcpipeline.PipelineBuilder
 
 project = "python-streaming-data-types"
 
-python_version = "3.8"
-
 container_build_nodes = [
   'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,7 @@ builders = pipeline_builder.createBuilders { container ->
 
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
-      yum install -yq wget
-      wget -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
       sh miniconda.sh -b -p miniconda
       miniconda/bin/conda create -n env python=${python_version}
       miniconda/bin/conda activate env

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,6 @@ builders = pipeline_builder.createBuilders { container ->
   }  // stage
 
   pipeline_builder.stage("${container.key}: Dependencies") {
-    def conan_remote = "ess-dmsc-local"
     container.sh """
       pip install --user -r ${project}/requirements.txt
       pip install --user -r ${project}/requirements-dev.txt
@@ -49,7 +48,7 @@ builders = pipeline_builder.createBuilders { container ->
     def test_output = "TestResults.xml"
     container.sh """
       cd ${project}
-      tox -- --junitxml=${test_output}
+      ${python} -m tox -- --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
       /opt/miniconda/bin/conda init bash
-      export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
       python --version
       python -m pip install --user -r ${project}/requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,18 @@ builders = pipeline_builder.createBuilders { container ->
     container.copyTo(pipeline_builder.project, pipeline_builder.project)
   }  // stage
 
-  pipeline_builder.stage("${container.key}: Dependencies") {
+  pipeline_builder.stage("${container.key}: Conda") {
     container.sh """
       curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-      sh miniconda.sh -b -p miniconda
-      miniconda/bin/conda init bash
-      miniconda/bin/conda create -n env python=${python_version}
-      miniconda/bin/conda activate env
+      sh miniconda.sh -b -p /home/jenkins/miniconda
+      /home/jenkins/miniconda/bin/conda init bash
+      /home/jenkins/miniconda/bin/conda create -n env python=${python_version}
+      echo "/home/nicos/miniconda/bin/conda activate env" >> ~/.bashrc
+    """
+  } // stage
+
+  pipeline_builder.stage("${container.key}: Dependencies") {
+    container.sh """
       python --version
       python -m pip install --user -r ${project}/requirements.txt
       python -m pip install --user -r ${project}/requirements-dev.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ builders = pipeline_builder.createBuilders { container ->
 
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
+      /opt/miniconda/bin/conda init bash
       export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
       /opt/miniconda/bin/python --version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,9 +48,8 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
-      ${python} --version
       cd ${project}
-      ${python} -m pytest --junitxml=${test_output}
+      tox -- --junitxml=${test_output}
     """
     container.copyFrom("${project}/${test_output}", ".")
     xunit thresholds: [failed(unstableThreshold: '0')], tools: [JUnit(deleteOutputFiles: true, pattern: '*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ builders = pipeline_builder.createBuilders { container ->
 
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
+      yum install -yq wget
       wget -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       sh miniconda.sh -b -p miniconda
       miniconda/bin/conda create -n env python=${python_version}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ builders = pipeline_builder.createBuilders { container ->
       /opt/miniconda/bin/conda init bash
       export PYTHONPATH=
       export PATH=/opt/miniconda/bin:$PATH
-      /opt/miniconda/bin/python --version
+      bin/python --version
       /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements.txt
       /opt/miniconda/bin/python -m pip install --user -r ${project}/requirements-dev.txt
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
+      export PATH=/opt/miniconda/bin:$PATH
       cd ${project}
       python -m tox -- --junitxml=${test_output}
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
+      /opt/miniconda/bin/conda init bash
       export PYTHONPATH=
       export PATH=/home/jenkins/miniconda/bin:$PATH
       cd ${project}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.PipelineBuilder
 project = "python-streaming-data-types"
 
 container_build_nodes = [
-  'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
+  'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
 ]
 
 // Define number of old builds to keep.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ builders = pipeline_builder.createBuilders { container ->
     container.sh """
       curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
       sh miniconda.sh -b -p /home/jenkins/miniconda
+      /home/jenkins/miniconda/bin/conda update -n base -c defaults conda -y
       /home/jenkins/miniconda/bin/conda init bash
       export PYTHONPATH=
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,15 +42,14 @@ builders = pipeline_builder.createBuilders { container ->
       curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
       sh miniconda.sh -b -p /home/jenkins/miniconda
       /home/jenkins/miniconda/bin/conda init bash
-      /home/jenkins/miniconda/bin/conda create -n env python=${python_version}
-      echo "/home/nicos/miniconda/bin/conda activate env" >> ~/.bashrc
       export PYTHONPATH=
     """
   } // stage
 
   pipeline_builder.stage("${container.key}: Dependencies") {
     container.sh """
-      export PATH=/home/jenkins/miniconda/envs/env/bin:$PATH
+      export PYTHONPATH=
+      export PATH=/home/jenkins/miniconda/bin:$PATH
       python --version
       python -m pip install --user -r ${project}/requirements.txt
       python -m pip install --user -r ${project}/requirements-dev.txt
@@ -60,7 +59,8 @@ builders = pipeline_builder.createBuilders { container ->
   pipeline_builder.stage("${container.key}: Test") {
     def test_output = "TestResults.xml"
     container.sh """
-      export PATH=/home/jenkins/miniconda/envs/env/bin:$PATH
+      export PYTHONPATH=
+      export PATH=/home/jenkins/miniconda/bin:$PATH
       cd ${project}
       python -m tox -- --junitxml=${test_output}
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py36, py37, py38, flake8
-requires = tox-conda
 isolated_build = true
 skipsdist=true
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ deps =
     -r requirements.txt
     -r requirements-dev.txt
 commands =
-    pytest {posargs}
+    python -m pytest {posargs}
 
 [testenv:flake8]
 commands =
-    flake8 tests src
+    python -m flake8 tests src

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py36, py37, py38, flake8
+requires = tox-conda
 isolated_build = true
 skipsdist=true
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ commands =
 
 [testenv:flake8]
 commands =
-    flake8 test src
+    flake8 tests src

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -r requirements.txt
     -r requirements-dev.txt
 commands =
-    pytest
+    pytest {posargs}
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
On Jenkins, it will use tox to run the unit tests against multiple versions of Python.
The easiest way to get this to work was install Conda as part of the process.