### PR TITLE
If the ns10 key is "    " then treat it as "" on deserialisation

### DIFF
--- a/streaming_data_types/nicos_cache_ns10.py
+++ b/streaming_data_types/nicos_cache_ns10.py
@@ -44,4 +44,4 @@ def deserialise_ns10(buffer):
 
     Entry = namedtuple("Entry", "key time_stamp ttl expired value")
 
-    return Entry(key.decode(), time_stamp, ttl, expired, value.decode())
+    return Entry(key.decode().strip(), time_stamp, ttl, expired, value.decode())


### PR DESCRIPTION
I'd rather do it here than in the clients.