### PR TITLE
Output buffer as bytes instead of bytearray

### DIFF
--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -185,4 +185,4 @@ def serialise_hs00(histogram):
     # Generate the output and replace the file_identifier
     buffer = builder.Output()
     buffer[4:8] = FILE_IDENTIFIER
-    return buffer
+    return bytes(buffer)

--- a/streaming_data_types/logdata_f142.py
+++ b/streaming_data_types/logdata_f142.py
@@ -485,7 +485,7 @@ def serialise_f142(
     timestamp_unix_ns: int = 0,
     alarm_status: Union[int, None] = None,
     alarm_severity: Union[int, None] = None,
-) -> bytearray:
+) -> bytes:
     """
     Serialise value and corresponding timestamp as an f142 Flatbuffer message.
     Should automagically use a sensible type for value in the message, but if
@@ -515,7 +515,9 @@ def serialise_f142(
     else:
         raise NotImplementedError("f142 only supports scalars or 1D array values")
 
-    return _complete_buffer(builder, timestamp_unix_ns, alarm_status, alarm_severity)
+    return bytes(
+        _complete_buffer(builder, timestamp_unix_ns, alarm_status, alarm_severity)
+    )
 
 
 def _serialise_value(
@@ -577,7 +579,7 @@ def _decode_if_scalar_string(value: np.ndarray) -> Union[str, np.ndarray]:
     return value
 
 
-def deserialise_f142(buffer: bytearray) -> NamedTuple:
+def deserialise_f142(buffer: Union[bytearray, bytes]) -> NamedTuple:
     check_schema_identifier(buffer, FILE_IDENTIFIER)
 
     log_data = LogData.LogData.GetRootAsLogData(buffer, 0)

--- a/streaming_data_types/nicos_cache_ns10.py
+++ b/streaming_data_types/nicos_cache_ns10.py
@@ -28,7 +28,7 @@ def serialise_ns10(
     buffer = builder.Output()
     buffer[4:8] = FILE_IDENTIFIER
 
-    return buffer
+    return bytes(buffer)
 
 
 def deserialise_ns10(buffer):

--- a/streaming_data_types/run_start_pl72.py
+++ b/streaming_data_types/run_start_pl72.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, NamedTuple
+from typing import Optional, NamedTuple, Union
 import flatbuffers
 from streaming_data_types.fbschemas.run_start_pl72 import RunStart
 from streaming_data_types.utils import check_schema_identifier
@@ -18,7 +18,7 @@ def serialise_pl72(
     service_id: str = "",
     instrument_name: str = "TEST",
     broker: str = "localhost:9092",
-) -> bytearray:
+) -> bytes:
     builder = flatbuffers.Builder(136)
 
     if start_time is None:
@@ -55,10 +55,10 @@ def serialise_pl72(
     # Generate the output and replace the file_identifier
     buffer = builder.Output()
     buffer[4:8] = FILE_IDENTIFIER
-    return buffer
+    return bytes(buffer)
 
 
-def deserialise_pl72(buffer: bytearray) -> NamedTuple:
+def deserialise_pl72(buffer: Union[bytearray, bytes]) -> NamedTuple:
     check_schema_identifier(buffer, FILE_IDENTIFIER)
 
     run_start = RunStart.RunStart.GetRootAsRunStart(buffer, 0)

--- a/streaming_data_types/run_stop_6s4t.py
+++ b/streaming_data_types/run_stop_6s4t.py
@@ -1,4 +1,4 @@
-from typing import Optional, NamedTuple
+from typing import Optional, NamedTuple, Union
 import flatbuffers
 from streaming_data_types.fbschemas.run_stop_6s4t import RunStop
 from streaming_data_types.utils import check_schema_identifier
@@ -12,7 +12,7 @@ def serialise_6s4t(
     run_name: str = "test_run",
     service_id: str = "",
     stop_time: Optional[int] = None,
-) -> bytearray:
+) -> bytes:
     builder = flatbuffers.Builder(136)
 
     if service_id is None:
@@ -37,10 +37,10 @@ def serialise_6s4t(
     # Generate the output and replace the file_identifier
     buffer = builder.Output()
     buffer[4:8] = FILE_IDENTIFIER
-    return buffer
+    return bytes(buffer)
 
 
-def deserialise_6s4t(buffer: bytearray) -> NamedTuple:
+def deserialise_6s4t(buffer: Union[bytearray, bytes]) -> NamedTuple:
     check_schema_identifier(buffer, FILE_IDENTIFIER)
 
     run_stop = RunStop.RunStop.GetRootAsRunStop(buffer, 0)

--- a/tests/test_6s4t.py
+++ b/tests/test_6s4t.py
@@ -25,7 +25,6 @@ class TestSerialisation6s4t:
         # Manually hack the id
         buf = bytearray(buf)
         buf[4:8] = b"1234"
-        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_6s4t(buf)

--- a/tests/test_6s4t.py
+++ b/tests/test_6s4t.py
@@ -23,7 +23,9 @@ class TestSerialisation6s4t:
         buf = serialise_6s4t(**self.original_entry)
 
         # Manually hack the id
+        buf = bytearray(buf)
         buf[4:8] = b"1234"
+        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_6s4t(buf)

--- a/tests/test_f142.py
+++ b/tests/test_f142.py
@@ -170,7 +170,9 @@ class TestSerialisationf142:
         buf = serialise_f142(**self.original_entry)
 
         # Manually hack the id
+        buf = bytearray(buf)
         buf[4:8] = b"1234"
+        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_f142(buf)

--- a/tests/test_f142.py
+++ b/tests/test_f142.py
@@ -172,7 +172,6 @@ class TestSerialisationf142:
         # Manually hack the id
         buf = bytearray(buf)
         buf[4:8] = b"1234"
-        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_f142(buf)

--- a/tests/test_hs00.py
+++ b/tests/test_hs00.py
@@ -145,7 +145,6 @@ class TestSerialisationHs00:
         # Manually hack the id
         buf = bytearray(buf)
         buf[4:8] = b"1234"
-        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_hs00(buf)

--- a/tests/test_hs00.py
+++ b/tests/test_hs00.py
@@ -49,7 +49,7 @@ class TestSerialisationHs00:
         )
 
     def test_serialises_and_deserialises_hs00_message_correctly_for_minimal_1d_data(
-        self
+        self,
     ):
         """
         Round-trip to check what we serialise is what we get back.
@@ -143,7 +143,9 @@ class TestSerialisationHs00:
         buf = serialise_hs00(original_hist)
 
         # Manually hack the id
+        buf = bytearray(buf)
         buf[4:8] = b"1234"
+        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_hs00(buf)

--- a/tests/test_ns10.py
+++ b/tests/test_ns10.py
@@ -37,7 +37,6 @@ class TestSerialisationNs10:
         # Manually hack the id
         buf = bytearray(buf)
         buf[4:8] = b"1234"
-        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_ns10(buf)

--- a/tests/test_ns10.py
+++ b/tests/test_ns10.py
@@ -35,7 +35,9 @@ class TestSerialisationNs10:
         buf = serialise_ns10(**original_entry)
 
         # Manually hack the id
+        buf = bytearray(buf)
         buf[4:8] = b"1234"
+        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_ns10(buf)

--- a/tests/test_pl72.py
+++ b/tests/test_pl72.py
@@ -37,7 +37,9 @@ class TestSerialisationPl72:
         buf = serialise_pl72(**self.original_entry)
 
         # Manually hack the id
+        buf = bytearray(buf)
         buf[4:8] = b"1234"
+        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_pl72(buf)

--- a/tests/test_pl72.py
+++ b/tests/test_pl72.py
@@ -39,7 +39,6 @@ class TestSerialisationPl72:
         # Manually hack the id
         buf = bytearray(buf)
         buf[4:8] = b"1234"
-        buf = bytes(buf)
 
         with pytest.raises(RuntimeError):
             deserialise_pl72(buf)


### PR DESCRIPTION
Not for merging until tested with NICOS.

Outputs serialised buffer as `bytes` so that a cast is not required when using the confluent kafka library. Not expected to require any changes in NICOS.