### PR TITLE
Changes required by just-bin-it

### DIFF
--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -170,10 +170,7 @@ def serialise_hs00(histogram):
 
     # Build the data
     data_len = reduce(operator.mul, histogram["current_shape"], 1)
-    if isinstance(histogram["data"], numpy.ndarray):
-        flattened_data = histogram["data"].flatten()
-    else:
-        flattened_data = numpy.asarray(histogram["data"]).flatten()
+    flattened_data = numpy.asarray(histogram["data"]).flatten()
 
     if numpy.issubdtype(flattened_data[0], numpy.int64):
         data_type = Array.ArrayULong

--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -1,7 +1,9 @@
 from functools import reduce
 import operator
 import flatbuffers
+import numpy
 import streaming_data_types.fbschemas.histogram_hs00.ArrayDouble as ArrayDouble
+import streaming_data_types.fbschemas.histogram_hs00.ArrayULong as ArrayULong
 import streaming_data_types.fbschemas.histogram_hs00.DimensionMetaData as DimensionMetaData
 import streaming_data_types.fbschemas.histogram_hs00.EventHistogram as EventHistogram
 from streaming_data_types.fbschemas.histogram_hs00.Array import Array
@@ -23,33 +25,40 @@ def deserialise_hs00(buffer):
 
     dims = []
     for i in range(event_hist.DimMetadataLength()):
-        bins_offset = event_hist.DimMetadata(i).BinBoundaries()
+        bins_fb = ArrayDouble.ArrayDouble()
+        if (
+            event_hist.DimMetadata(i).BinBoundariesType() == Array.ArrayUInt
+            or event_hist.DimMetadata(i).BinBoundariesType() == Array.ArrayULong
+        ):
+            bins_fb = ArrayULong.ArrayULong()
 
         # Get bins
-        bins_fb = ArrayDouble.ArrayDouble()
+        bins_offset = event_hist.DimMetadata(i).BinBoundaries()
         bins_fb.Init(bins_offset.Bytes, bins_offset.Pos)
         bin_boundaries = bins_fb.ValueAsNumpy()
-
-        # Check type
-        if event_hist.DimMetadata(i).BinBoundariesType() != Array.ArrayDouble:
-            raise TypeError("Type of the bin boundaries is incorrect, should be double")
 
         hist_info = {
             "length": event_hist.DimMetadata(i).Length(),
             "bin_boundaries": bin_boundaries,
-            "unit": event_hist.DimMetadata(i).Unit().decode("utf-8"),
-            "label": event_hist.DimMetadata(i).Label().decode("utf-8"),
+            "unit": event_hist.DimMetadata(i).Unit().decode("utf-8")
+            if event_hist.DimMetadata(i).Unit()
+            else "",
+            "label": event_hist.DimMetadata(i).Label().decode("utf-8")
+            if event_hist.DimMetadata(i).Label()
+            else "",
         }
         dims.append(hist_info)
 
     metadata_timestamp = event_hist.LastMetadataTimestamp()
 
-    # Get the data
-    if event_hist.DataType() != Array.ArrayDouble:
-        raise TypeError("Type of the data array is incorrect")
+    data_fb = ArrayDouble.ArrayDouble()
+    if (
+        event_hist.DataType() == Array.ArrayUInt
+        or event_hist.DataType() == Array.ArrayULong
+    ):
+        data_fb = ArrayULong.ArrayULong()
 
     data_offset = event_hist.Data()
-    data_fb = ArrayDouble.ArrayDouble()
     data_fb.Init(data_offset.Bytes, data_offset.Pos)
     shape = event_hist.CurrentShapeAsNumpy().tolist()
     data = data_fb.ValueAsNumpy().reshape(shape)
@@ -58,6 +67,11 @@ def deserialise_hs00(buffer):
     errors_offset = event_hist.Errors()
     if errors_offset:
         errors_fb = ArrayDouble.ArrayDouble()
+        if (
+            event_hist.DataType() == Array.ArrayUInt
+            or event_hist.DataType() == Array.ArrayULong
+        ):
+            errors_fb = ArrayULong.ArrayULong()
         errors_fb.Init(errors_offset.Bytes, errors_offset.Pos)
         errors = errors_fb.ValueAsNumpy().reshape(shape)
     else:
@@ -80,20 +94,35 @@ def _serialise_metadata(builder, length, edges, unit, label):
     unit_offset = builder.CreateString(unit)
     label_offset = builder.CreateString(label)
 
-    ArrayDouble.ArrayDoubleStartValueVector(builder, len(edges))
-    # FlatBuffers builds arrays backwards
-    for x in reversed(edges):
-        builder.PrependFloat64(x)
-    bins_vector = builder.EndVector(len(edges))
-    # Add the bins
-    ArrayDouble.ArrayDoubleStart(builder)
-    ArrayDouble.ArrayDoubleAddValue(builder, bins_vector)
-    bins_offset = ArrayDouble.ArrayDoubleEnd(builder)
+    if isinstance(edges[0], int) or (
+        isinstance(edges, numpy.ndarray) and numpy.issubdtype(edges[0], numpy.int64)
+    ):
+        bin_type = Array.ArrayULong
+        ArrayULong.ArrayULongStartValueVector(builder, len(edges))
+        # FlatBuffers builds arrays backwards
+        for x in reversed(edges):
+            builder.PrependUint64(x)
+        bins_vector = builder.EndVector(len(edges))
+        # Add the bins
+        ArrayULong.ArrayULongStart(builder)
+        ArrayULong.ArrayULongAddValue(builder, bins_vector)
+        bins_offset = ArrayULong.ArrayULongEnd(builder)
+    else:
+        bin_type = Array.ArrayDouble
+        ArrayDouble.ArrayDoubleStartValueVector(builder, len(edges))
+        # FlatBuffers builds arrays backwards
+        for x in reversed(edges):
+            builder.PrependFloat64(x)
+        bins_vector = builder.EndVector(len(edges))
+        # Add the bins
+        ArrayDouble.ArrayDoubleStart(builder)
+        ArrayDouble.ArrayDoubleAddValue(builder, bins_vector)
+        bins_offset = ArrayDouble.ArrayDoubleEnd(builder)
 
     DimensionMetaData.DimensionMetaDataStart(builder)
     DimensionMetaData.DimensionMetaDataAddLength(builder, length)
     DimensionMetaData.DimensionMetaDataAddBinBoundaries(builder, bins_offset)
-    DimensionMetaData.DimensionMetaDataAddBinBoundariesType(builder, Array.ArrayDouble)
+    DimensionMetaData.DimensionMetaDataAddBinBoundariesType(builder, bin_type)
     DimensionMetaData.DimensionMetaDataAddLabel(builder, label_offset)
     DimensionMetaData.DimensionMetaDataAddUnit(builder, unit_offset)
     return DimensionMetaData.DimensionMetaDataEnd(builder)
@@ -141,25 +170,57 @@ def serialise_hs00(histogram):
 
     # Build the data
     data_len = reduce(operator.mul, histogram["current_shape"], 1)
+    if isinstance(histogram["data"], numpy.ndarray):
+        flattened_data = histogram["data"].flatten()
+    else:
+        flattened_data = numpy.asarray(histogram["data"]).flatten()
 
-    ArrayDouble.ArrayDoubleStartValueVector(builder, data_len)
-    # FlatBuffers builds arrays backwards
-    for x in reversed(histogram["data"].flatten()):
-        builder.PrependFloat64(x)
-    data_vector = builder.EndVector(data_len)
-    ArrayDouble.ArrayDoubleStart(builder)
-    ArrayDouble.ArrayDoubleAddValue(builder, data_vector)
-    data_offset = ArrayDouble.ArrayDoubleEnd(builder)
+    if numpy.issubdtype(flattened_data[0], numpy.int64):
+        data_type = Array.ArrayULong
+        ArrayULong.ArrayULongStartValueVector(builder, data_len)
+        # FlatBuffers builds arrays backwards
+        for x in reversed(flattened_data):
+            builder.PrependUint64(x)
+        data_vector = builder.EndVector(data_len)
+        ArrayULong.ArrayULongStart(builder)
+        ArrayULong.ArrayULongAddValue(builder, data_vector)
+        data_offset = ArrayULong.ArrayULongEnd(builder)
+    else:
+        data_type = Array.ArrayDouble
+        ArrayDouble.ArrayDoubleStartValueVector(builder, data_len)
+        # FlatBuffers builds arrays backwards
+        for x in reversed(flattened_data):
+            builder.PrependFloat64(x)
+        data_vector = builder.EndVector(data_len)
+        ArrayDouble.ArrayDoubleStart(builder)
+        ArrayDouble.ArrayDoubleAddValue(builder, data_vector)
+        data_offset = ArrayDouble.ArrayDoubleEnd(builder)
 
     errors_offset = None
     if "errors" in histogram:
-        ArrayDouble.ArrayDoubleStartValueVector(builder, data_len)
-        for x in reversed(histogram["errors"].flatten()):
-            builder.PrependFloat64(x)
-        errors = builder.EndVector(data_len)
-        ArrayDouble.ArrayDoubleStart(builder)
-        ArrayDouble.ArrayDoubleAddValue(builder, errors)
-        errors_offset = ArrayDouble.ArrayDoubleEnd(builder)
+        if isinstance(histogram["errors"], numpy.ndarray):
+            flattened_data = histogram["errors"].flatten()
+        else:
+            flattened_data = numpy.asarray(histogram["errors"]).flatten()
+
+        if numpy.issubdtype(flattened_data[0], numpy.int64):
+            error_type = Array.ArrayULong
+            ArrayULong.ArrayULongStartValueVector(builder, data_len)
+            for x in reversed(flattened_data):
+                builder.PrependUint64(x)
+            errors = builder.EndVector(data_len)
+            ArrayULong.ArrayULongStart(builder)
+            ArrayULong.ArrayULongAddValue(builder, errors)
+            errors_offset = ArrayULong.ArrayULongEnd(builder)
+        else:
+            error_type = Array.ArrayDouble
+            ArrayDouble.ArrayDoubleStartValueVector(builder, data_len)
+            for x in reversed(flattened_data):
+                builder.PrependFloat64(x)
+            errors = builder.EndVector(data_len)
+            ArrayDouble.ArrayDoubleStart(builder)
+            ArrayDouble.ArrayDoubleAddValue(builder, errors)
+            errors_offset = ArrayDouble.ArrayDoubleEnd(builder)
 
     # Build the actual buffer
     EventHistogram.EventHistogramStart(builder)
@@ -171,10 +232,10 @@ def serialise_hs00(histogram):
     EventHistogram.EventHistogramAddTimestamp(builder, histogram["timestamp"])
     if source_offset:
         EventHistogram.EventHistogramAddSource(builder, source_offset)
-    EventHistogram.EventHistogramAddDataType(builder, Array.ArrayDouble)
+    EventHistogram.EventHistogramAddDataType(builder, data_type)
     if errors_offset:
         EventHistogram.EventHistogramAddErrors(builder, errors_offset)
-        EventHistogram.EventHistogramAddErrorsType(builder, Array.ArrayDouble)
+        EventHistogram.EventHistogramAddErrorsType(builder, error_type)
     if "last_metadata_timestamp" in histogram:
         EventHistogram.EventHistogramAddLastMetadataTimestamp(
             builder, histogram["last_metadata_timestamp"]

--- a/tests/test_hs00.py
+++ b/tests/test_hs00.py
@@ -23,12 +23,12 @@ class TestSerialisationHs00:
                     "length": 5,
                     "unit": "m",
                     "label": "some_label",
-                    "bin_boundaries": [0, 1, 2, 3, 4, 5],
+                    "bin_boundaries": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
                 }
             ],
             "last_metadata_timestamp": 123456,
-            "data": np.array([1, 2, 3, 4, 5]),
-            "errors": np.array([5, 4, 3, 2, 1]),
+            "data": np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+            "errors": np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
             "info": "info_string",
         }
 
@@ -62,10 +62,10 @@ class TestSerialisationHs00:
                     "length": 5,
                     "unit": "m",
                     "label": "some_label",
-                    "bin_boundaries": [0, 1, 2, 3, 4, 5],
+                    "bin_boundaries": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
                 }
             ],
-            "data": np.array([1, 2, 3, 4, 5]),
+            "data": np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
         }
         buf = serialise_hs00(original_hist)
 
@@ -93,18 +93,18 @@ class TestSerialisationHs00:
                     "length": 2,
                     "unit": "b",
                     "label": "y",
-                    "bin_boundaries": np.array([10, 11, 12]),
+                    "bin_boundaries": np.array([10.0, 11.0, 12.0]),
                 },
                 {
                     "length": 5,
                     "unit": "m",
                     "label": "x",
-                    "bin_boundaries": [0, 1, 2, 3, 4, 5],
+                    "bin_boundaries": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
                 },
             ],
             "last_metadata_timestamp": 123456,
-            "data": np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
-            "errors": np.array([[5, 4, 3, 2, 1], [10, 9, 8, 7, 6]]),
+            "data": np.array([[1.0, 2.0, 3.0, 4.0, 5.0], [6.0, 7.0, 8.0, 9.0, 10.0]]),
+            "errors": np.array([[5.0, 4.0, 3.0, 2.0, 1.0], [10.0, 9.0, 8.0, 7.0, 6.0]]),
             "info": "info_string",
         }
         buf = serialise_hs00(original_hist)
@@ -135,10 +135,10 @@ class TestSerialisationHs00:
                     "length": 5,
                     "unit": "m",
                     "label": "some_label",
-                    "bin_boundaries": [0, 1, 2, 3, 4, 5],
+                    "bin_boundaries": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
                 }
             ],
-            "data": np.array([1, 2, 3, 4, 5]),
+            "data": np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
         }
         buf = serialise_hs00(original_hist)
 
@@ -148,3 +148,139 @@ class TestSerialisationHs00:
 
         with pytest.raises(RuntimeError):
             deserialise_hs00(buf)
+
+    def test_serialises_and_deserialises_hs00_message_correctly_for_int_array_data(
+        self
+    ):
+        """
+        Round-trip to check what we serialise is what we get back.
+        """
+        original_hist = {
+            "source": "some_source",
+            "timestamp": 123456,
+            "current_shape": [5],
+            "dim_metadata": [
+                {
+                    "length": 5,
+                    "unit": "m",
+                    "label": "some_label",
+                    "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]),
+                }
+            ],
+            "last_metadata_timestamp": 123456,
+            "data": np.array([1, 2, 3, 4, 5]),
+            "errors": np.array([5, 4, 3, 2, 1]),
+            "info": "info_string",
+        }
+
+        buf = serialise_hs00(original_hist)
+        hist = deserialise_hs00(buf)
+
+        assert hist["source"] == original_hist["source"]
+        assert hist["timestamp"] == original_hist["timestamp"]
+        assert hist["current_shape"] == original_hist["current_shape"]
+        self._check_metadata_for_one_dimension(
+            hist["dim_metadata"][0], original_hist["dim_metadata"][0]
+        )
+        assert np.array_equal(hist["data"], original_hist["data"])
+        assert np.array_equal(hist["errors"], original_hist["errors"])
+        assert hist["info"] == original_hist["info"]
+        assert (
+            hist["last_metadata_timestamp"] == original_hist["last_metadata_timestamp"]
+        )
+
+    def test_serialises_and_deserialises_hs00_message_correctly_when_float_input_is_not_ndarray(
+        self
+    ):
+        """
+        Round-trip to check what we serialise is what we get back.
+        """
+        original_hist = {
+            "source": "some_source",
+            "timestamp": 123456,
+            "current_shape": [2, 5],
+            "dim_metadata": [
+                {
+                    "length": 2,
+                    "unit": "b",
+                    "label": "y",
+                    "bin_boundaries": [10.0, 11.0, 12.0],
+                },
+                {
+                    "length": 5,
+                    "unit": "m",
+                    "label": "x",
+                    "bin_boundaries": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                },
+            ],
+            "last_metadata_timestamp": 123456,
+            "data": [[1.0, 2.0, 3.0, 4.0, 5.0], [6.0, 7.0, 8.0, 9.0, 10.0]],
+            "errors": [[5.0, 4.0, 3.0, 2.0, 1.0], [10.0, 9.0, 8.0, 7.0, 6.0]],
+            "info": "info_string",
+        }
+        buf = serialise_hs00(original_hist)
+
+        hist = deserialise_hs00(buf)
+        assert hist["source"] == original_hist["source"]
+        assert hist["timestamp"] == original_hist["timestamp"]
+        assert hist["current_shape"] == original_hist["current_shape"]
+        self._check_metadata_for_one_dimension(
+            hist["dim_metadata"][0], original_hist["dim_metadata"][0]
+        )
+        self._check_metadata_for_one_dimension(
+            hist["dim_metadata"][1], original_hist["dim_metadata"][1]
+        )
+        assert np.array_equal(hist["data"], original_hist["data"])
+        assert np.array_equal(hist["errors"], original_hist["errors"])
+        assert hist["info"] == original_hist["info"]
+        assert (
+            hist["last_metadata_timestamp"] == original_hist["last_metadata_timestamp"]
+        )
+
+    def test_serialises_and_deserialises_hs00_message_correctly_when_int_input_is_not_ndarray(
+        self
+    ):
+        """
+        Round-trip to check what we serialise is what we get back.
+        """
+        original_hist = {
+            "source": "some_source",
+            "timestamp": 123456,
+            "current_shape": [2, 5],
+            "dim_metadata": [
+                {
+                    "length": 2,
+                    "unit": "b",
+                    "label": "y",
+                    "bin_boundaries": [10, 11, 12],
+                },
+                {
+                    "length": 5,
+                    "unit": "m",
+                    "label": "x",
+                    "bin_boundaries": [0, 1, 2, 3, 4, 5],
+                },
+            ],
+            "last_metadata_timestamp": 123456,
+            "data": [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
+            "errors": [[5, 4, 3, 2, 1], [10, 9, 8, 7, 6]],
+            "info": "info_string",
+        }
+        buf = serialise_hs00(original_hist)
+
+        hist = deserialise_hs00(buf)
+        assert hist["source"] == original_hist["source"]
+        assert hist["timestamp"] == original_hist["timestamp"]
+        assert hist["current_shape"] == original_hist["current_shape"]
+        self._check_metadata_for_one_dimension(
+            hist["dim_metadata"][0], original_hist["dim_metadata"][0]
+        )
+        self._check_metadata_for_one_dimension(
+            hist["dim_metadata"][1], original_hist["dim_metadata"][1]
+        )
+        assert np.array_equal(hist["data"], original_hist["data"])
+        assert np.array_equal(hist["errors"], original_hist["errors"])
+        assert hist["info"] == original_hist["info"]
+        assert (
+            hist["last_metadata_timestamp"] == original_hist["last_metadata_timestamp"]
+        )


### PR DESCRIPTION
Whilst porting just-bin-it to use this module's hs00 I had to make some changes to handle unpopulated string fields.

While I was there I made it so it handles both float and int type arrays and added the corresponding tests.
Also, it also no longer cares if the arrays are ndarray or lists, it will convert to ndarray where necessary.