### PR TITLE
Serialise to bytes not bytearray

### DIFF
--- a/streaming_data_types/status_x5f2.py
+++ b/streaming_data_types/status_x5f2.py
@@ -49,7 +49,7 @@ def serialise_x5f2(
         host_name: str,
         process_id: int,
         update_interval: int,
-        status_json: str):
+        status_json: str) -> bytes:
     """
     Serialise status message as an x5f2 FlatBuffers message.
 
@@ -88,4 +88,4 @@ def serialise_x5f2(
     # Generate the output and replace the file_identifier
     buffer = builder.Output()
     buffer[4:8] = FILE_IDENTIFIER
-    return buffer
+    return bytes(buffer)


### PR DESCRIPTION
Outputting the buffer as `bytes`, rather than `bytearray` is more convenient for compatibility with the `confluent-kafka` python library. It doesn't affect use with `kafka-python`.