### PR TITLE
Support more types for hs00 data

### DIFF
--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -23,7 +23,7 @@ _array_for_type = {
 
 
 def _create_array_object_for_type(array_type):
-    return _array_for_type.get(array_type, default=ArrayDouble.ArrayDouble())
+    return _array_for_type.get(array_type, ArrayDouble.ArrayDouble())
 
 
 def deserialise_hs00(buffer):

--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -15,15 +15,15 @@ from streaming_data_types.utils import check_schema_identifier
 FILE_IDENTIFIER = b"hs00"
 
 
+_array_for_type = {
+    Array.ArrayUInt: ArrayUInt.ArrayUInt(),
+    Array.ArrayULong: ArrayULong.ArrayULong(),
+    Array.ArrayFloat: ArrayFloat.ArrayFloat(),
+}
+
+
 def _create_array_object_for_type(array_type):
-    if array_type == Array.ArrayUInt:
-        return ArrayUInt.ArrayUInt()
-    elif array_type == Array.ArrayULong:
-        return ArrayULong.ArrayULong()
-    elif array_type == Array.ArrayFloat:
-        return ArrayFloat.ArrayFloat()
-    else:
-        return ArrayDouble.ArrayDouble()
+    return _array_for_type.get(array_type, default=ArrayDouble.ArrayDouble())
 
 
 def deserialise_hs00(buffer):
@@ -190,18 +190,18 @@ def _serialise_array(builder, data_len, data):
     # Carefully preserve explicitly supported types
     if numpy.issubdtype(flattened_data.dtype, numpy.uint32):
         return _serialise_uint32(builder, data_len, flattened_data)
-    elif numpy.issubdtype(flattened_data.dtype, numpy.uint64):
+    if numpy.issubdtype(flattened_data.dtype, numpy.uint64):
         return _serialise_uint64(builder, data_len, flattened_data)
-    elif numpy.issubdtype(flattened_data.dtype, numpy.float32):
+    if numpy.issubdtype(flattened_data.dtype, numpy.float32):
         return _serialise_float(builder, data_len, flattened_data)
-    elif numpy.issubdtype(flattened_data.dtype, numpy.float64):
+    if numpy.issubdtype(flattened_data.dtype, numpy.float64):
         return _serialise_double(builder, data_len, flattened_data)
 
     # Otherwise if it looks like an int then use uint64, or use double as last resort
-    elif numpy.issubdtype(flattened_data.dtype, numpy.int64):
+    if numpy.issubdtype(flattened_data.dtype, numpy.int64):
         return _serialise_uint64(builder, data_len, flattened_data)
-    else:
-        return _serialise_double(builder, data_len, flattened_data)
+
+    return _serialise_double(builder, data_len, flattened_data)
 
 
 def _serialise_float(builder, data_len, flattened_data):

--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -97,27 +97,9 @@ def _serialise_metadata(builder, length, edges, unit, label):
     if isinstance(edges[0], int) or (
         isinstance(edges, numpy.ndarray) and numpy.issubdtype(edges[0], numpy.int64)
     ):
-        bin_type = Array.ArrayULong
-        ArrayULong.ArrayULongStartValueVector(builder, len(edges))
-        # FlatBuffers builds arrays backwards
-        for x in reversed(edges):
-            builder.PrependUint64(x)
-        bins_vector = builder.EndVector(len(edges))
-        # Add the bins
-        ArrayULong.ArrayULongStart(builder)
-        ArrayULong.ArrayULongAddValue(builder, bins_vector)
-        bins_offset = ArrayULong.ArrayULongEnd(builder)
+        bins_offset, bin_type = _serialise_uint64(builder, len(edges), edges)
     else:
-        bin_type = Array.ArrayDouble
-        ArrayDouble.ArrayDoubleStartValueVector(builder, len(edges))
-        # FlatBuffers builds arrays backwards
-        for x in reversed(edges):
-            builder.PrependFloat64(x)
-        bins_vector = builder.EndVector(len(edges))
-        # Add the bins
-        ArrayDouble.ArrayDoubleStart(builder)
-        ArrayDouble.ArrayDoubleAddValue(builder, bins_vector)
-        bins_offset = ArrayDouble.ArrayDoubleEnd(builder)
+        bins_offset, bin_type = _serialise_double(builder, len(edges), edges)
 
     DimensionMetaData.DimensionMetaDataStart(builder)
     DimensionMetaData.DimensionMetaDataAddLength(builder, length)

--- a/tests/test_hs00.py
+++ b/tests/test_hs00.py
@@ -4,6 +4,26 @@ from streaming_data_types.histogram_hs00 import serialise_hs00, deserialise_hs00
 from streaming_data_types import SERIALISERS, DESERIALISERS
 
 
+def create_test_data_with_type(numpy_type):
+    return {
+        "source": "some_source",
+        "timestamp": 123456,
+        "current_shape": [5],
+        "dim_metadata": [
+            {
+                "length": 5,
+                "unit": "m",
+                "label": "some_label",
+                "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]).astype(numpy_type),
+            }
+        ],
+        "last_metadata_timestamp": 123456,
+        "data": np.array([1, 2, 3, 4, 5]).astype(numpy_type),
+        "errors": np.array([5, 4, 3, 2, 1]).astype(numpy_type),
+        "info": "info_string",
+    }
+
+
 class TestSerialisationHs00:
     def _check_metadata_for_one_dimension(self, data, original_data):
         assert np.array_equal(data["bin_boundaries"], original_data["bin_boundaries"])
@@ -190,27 +210,21 @@ class TestSerialisationHs00:
             hist["last_metadata_timestamp"] == original_hist["last_metadata_timestamp"]
         )
 
-    def test_serialise_and_deserialise_hs00_message_returns_int32_type(self):
-        """
-        Round-trip to check what we serialise is what we get back.
-        """
-        original_hist = {
-            "source": "some_source",
-            "timestamp": 123456,
-            "current_shape": [5],
-            "dim_metadata": [
-                {
-                    "length": 5,
-                    "unit": "m",
-                    "label": "some_label",
-                    "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]).astype(np.int32),
-                }
-            ],
-            "last_metadata_timestamp": 123456,
-            "data": np.array([1, 2, 3, 4, 5]).astype(np.int32),
-            "errors": np.array([5, 4, 3, 2, 1]).astype(np.int32),
-            "info": "info_string",
-        }
+    def test_serialise_and_deserialise_hs00_message_returns_uint32_type(self):
+        original_hist = create_test_data_with_type(np.uint32)
+
+        buf = serialise_hs00(original_hist)
+        hist = deserialise_hs00(buf)
+
+        assert np.issubdtype(
+            hist["dim_metadata"][0]["bin_boundaries"].dtype,
+            original_hist["dim_metadata"][0]["bin_boundaries"].dtype,
+        )
+        assert np.issubdtype(hist["data"].dtype, original_hist["data"].dtype)
+        assert np.issubdtype(hist["errors"].dtype, original_hist["errors"].dtype)
+
+    def test_serialise_and_deserialise_hs00_message_returns_uint64_type(self):
+        original_hist = create_test_data_with_type(np.uint64)
 
         buf = serialise_hs00(original_hist)
         hist = deserialise_hs00(buf)
@@ -223,26 +237,20 @@ class TestSerialisationHs00:
         assert np.issubdtype(hist["errors"].dtype, original_hist["errors"].dtype)
 
     def test_serialise_and_deserialise_hs00_message_returns_float32_type(self):
-        """
-        Round-trip to check what we serialise is what we get back.
-        """
-        original_hist = {
-            "source": "some_source",
-            "timestamp": 123456,
-            "current_shape": [5],
-            "dim_metadata": [
-                {
-                    "length": 5,
-                    "unit": "m",
-                    "label": "some_label",
-                    "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]).astype(np.float32),
-                }
-            ],
-            "last_metadata_timestamp": 123456,
-            "data": np.array([1, 2, 3, 4, 5]).astype(np.float32),
-            "errors": np.array([5, 4, 3, 2, 1]).astype(np.float32),
-            "info": "info_string",
-        }
+        original_hist = create_test_data_with_type(np.float32)
+
+        buf = serialise_hs00(original_hist)
+        hist = deserialise_hs00(buf)
+
+        assert np.issubdtype(
+            hist["dim_metadata"][0]["bin_boundaries"].dtype,
+            original_hist["dim_metadata"][0]["bin_boundaries"].dtype,
+        )
+        assert np.issubdtype(hist["data"].dtype, original_hist["data"].dtype)
+        assert np.issubdtype(hist["errors"].dtype, original_hist["errors"].dtype)
+
+    def test_serialise_and_deserialise_hs00_message_returns_float64_type(self):
+        original_hist = create_test_data_with_type(np.float64)
 
         buf = serialise_hs00(original_hist)
         hist = deserialise_hs00(buf)

--- a/tests/test_hs00.py
+++ b/tests/test_hs00.py
@@ -151,7 +151,7 @@ class TestSerialisationHs00:
             deserialise_hs00(buf)
 
     def test_serialises_and_deserialises_hs00_message_correctly_for_int_array_data(
-        self
+        self,
     ):
         """
         Round-trip to check what we serialise is what we get back.
@@ -190,8 +190,72 @@ class TestSerialisationHs00:
             hist["last_metadata_timestamp"] == original_hist["last_metadata_timestamp"]
         )
 
+    def test_serialise_and_deserialise_hs00_message_returns_int32_type(self):
+        """
+        Round-trip to check what we serialise is what we get back.
+        """
+        original_hist = {
+            "source": "some_source",
+            "timestamp": 123456,
+            "current_shape": [5],
+            "dim_metadata": [
+                {
+                    "length": 5,
+                    "unit": "m",
+                    "label": "some_label",
+                    "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]).astype(np.int32),
+                }
+            ],
+            "last_metadata_timestamp": 123456,
+            "data": np.array([1, 2, 3, 4, 5]).astype(np.int32),
+            "errors": np.array([5, 4, 3, 2, 1]).astype(np.int32),
+            "info": "info_string",
+        }
+
+        buf = serialise_hs00(original_hist)
+        hist = deserialise_hs00(buf)
+
+        assert np.issubdtype(
+            hist["dim_metadata"][0]["bin_boundaries"].dtype,
+            original_hist["dim_metadata"][0]["bin_boundaries"].dtype,
+        )
+        assert np.issubdtype(hist["data"].dtype, original_hist["data"].dtype)
+        assert np.issubdtype(hist["errors"].dtype, original_hist["errors"].dtype)
+
+    def test_serialise_and_deserialise_hs00_message_returns_float32_type(self):
+        """
+        Round-trip to check what we serialise is what we get back.
+        """
+        original_hist = {
+            "source": "some_source",
+            "timestamp": 123456,
+            "current_shape": [5],
+            "dim_metadata": [
+                {
+                    "length": 5,
+                    "unit": "m",
+                    "label": "some_label",
+                    "bin_boundaries": np.array([0, 1, 2, 3, 4, 5]).astype(np.float32),
+                }
+            ],
+            "last_metadata_timestamp": 123456,
+            "data": np.array([1, 2, 3, 4, 5]).astype(np.float32),
+            "errors": np.array([5, 4, 3, 2, 1]).astype(np.float32),
+            "info": "info_string",
+        }
+
+        buf = serialise_hs00(original_hist)
+        hist = deserialise_hs00(buf)
+
+        assert np.issubdtype(
+            hist["dim_metadata"][0]["bin_boundaries"].dtype,
+            original_hist["dim_metadata"][0]["bin_boundaries"].dtype,
+        )
+        assert np.issubdtype(hist["data"].dtype, original_hist["data"].dtype)
+        assert np.issubdtype(hist["errors"].dtype, original_hist["errors"].dtype)
+
     def test_serialises_and_deserialises_hs00_message_correctly_when_float_input_is_not_ndarray(
-        self
+        self,
     ):
         """
         Round-trip to check what we serialise is what we get back.
@@ -239,7 +303,7 @@ class TestSerialisationHs00:
         )
 
     def test_serialises_and_deserialises_hs00_message_correctly_when_int_input_is_not_ndarray(
-        self
+        self,
     ):
         """
         Round-trip to check what we serialise is what we get back.


### PR DESCRIPTION
Closes DM-1979

hs00 serialisation and deserialisation only had support for 64 bit types, which was causing a problem when trying to use it for system tests with the ISIS Instrument Control Program.

Added unit tests to demonstrate that type is now preserved through a serialisation-deserialisation roundtrip if numpy types `np.uint32`, `np.uint64`, `np.float32` or `np.float64` are used for the histogram data, bin edges or error arrays.