### PR TITLE
Use official flake8 repo for pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
       language_version: python3.7
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.8.3
     hooks:
     - id: flake8


### PR DESCRIPTION
Rather than an old version on the pre-commit site.