### PR TITLE
Fix bug when serialising single timestamp to tdct

### DIFF
--- a/streaming_data_types/timestamps_tdct.py
+++ b/streaming_data_types/timestamps_tdct.py
@@ -23,7 +23,7 @@ def serialise_tdct(
 ) -> bytes:
     builder = flatbuffers.Builder(136)
 
-    timestamps = np.array(timestamps).astype(np.uint64)
+    timestamps = np.atleast_1d(np.array(timestamps)).astype(np.uint64)
 
     name_offset = builder.CreateString(name)
 

--- a/tests/test_tdct.py
+++ b/tests/test_tdct.py
@@ -27,13 +27,20 @@ class TestSerialisationTdct:
     def test_serialises_and_deserialises_tdct_message_with_array_of_timestamps(self):
         original_entry = {"name": "some_name", "timestamps": np.array([0, 1, 2, 3, 4])}
 
-        buf = serialise_tdct(**self.original_entry)
+        buf = serialise_tdct(**original_entry)
         deserialised_tuple = deserialise_tdct(buf)
 
         assert deserialised_tuple.name == original_entry["name"]
-        assert np.allclose(
-            deserialised_tuple.timestamps, self.original_entry["timestamps"]
-        )
+        assert np.allclose(deserialised_tuple.timestamps, original_entry["timestamps"])
+
+    def test_serialises_and_deserialises_tdct_message_with_single_timestamp(self):
+        original_entry = {"name": "some_name", "timestamps": np.array(0)}
+
+        buf = serialise_tdct(**original_entry)
+        deserialised_tuple = deserialise_tdct(buf)
+
+        assert deserialised_tuple.name == original_entry["name"]
+        assert np.allclose(deserialised_tuple.timestamps, original_entry["timestamps"])
 
     def test_if_buffer_has_wrong_id_then_throws(self):
         buf = serialise_tdct(**self.original_entry)


### PR DESCRIPTION
Fix bug encountered when testing the Forwarder.
The new unit test added here should provide explanation.