### PR TITLE
Make sure tests are not included in the wheel

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -46,7 +46,7 @@ tox
 
 #### Steps
 
-Delete any old builds you may have:
+Delete any old builds you may have (IMPORTANT!):
 ```
 rm -rf build dist
 ```

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="ScreamingUdder",
     url="https://github.com/ess-dmsc/python-streaming-data-types",
     license="BSD 2-Clause License",
-    packages=find_packages(exclude="tests"),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6.0",
     install_requires=["flatbuffers", "numpy"],
     extras_require={"dev": ["flake8", "pre-commit", "pytest", "tox"]},


### PR DESCRIPTION
Excluding `tests` folder is not sufficient to stop the tests appearing in the wheel and, thus, being installed in the root of site-packages (bad form!).

Doesn't require a new release as it is not causing an issue.