### PR TITLE
Update outdated/faulty code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 
 setup(
     name="ess_streaming_data_types",
-    version="0.9.2",
+    version="0.9.3",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/streaming_data_types/action_response_answ.py
+++ b/streaming_data_types/action_response_answ.py
@@ -23,6 +23,7 @@ def serialise_answ(
     stop_time: datetime,
 ) -> bytes:
     builder = flatbuffers.Builder(500)
+    builder.ForceDefaults(True)
     service_id_offset = builder.CreateString(service_id)
     job_id_offset = builder.CreateString(job_id)
     message_offset = builder.CreateString(message)
@@ -39,11 +40,8 @@ def serialise_answ(
     ActionResponse.ActionResponseAddStopTime(builder, int(stop_time.timestamp() * 1000))
 
     out_message = ActionResponse.ActionResponseEnd(builder)
-    builder.Finish(out_message)
-    output_buffer = builder.Output()
-    output_buffer[4:8] = FILE_IDENTIFIER
-
-    return bytes(output_buffer)
+    builder.Finish(out_message, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 Response = NamedTuple(

--- a/streaming_data_types/epics_connection_info_ep00.py
+++ b/streaming_data_types/epics_connection_info_ep00.py
@@ -17,6 +17,7 @@ def serialise_ep00(
     service_id: Optional[str] = None,
 ) -> bytes:
     builder = flatbuffers.Builder(136)
+    builder.ForceDefaults(True)
 
     if service_id is not None:
         service_id_offset = builder.CreateString(service_id)
@@ -30,12 +31,8 @@ def serialise_ep00(
     EpicsConnectionInfo.EpicsConnectionInfoAddTimestamp(builder, timestamp_ns)
 
     end = EpicsConnectionInfo.EpicsConnectionInfoEnd(builder)
-    builder.Finish(end)
-
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(end, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 EpicsConnection = namedtuple(

--- a/streaming_data_types/eventdata_ev42.py
+++ b/streaming_data_types/eventdata_ev42.py
@@ -69,6 +69,7 @@ def serialise_ev42(
     :return:
     """
     builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
 
     source = builder.CreateString(source_name)
 
@@ -108,9 +109,6 @@ def serialise_ev42(
         EventMessage.EventMessageAddFacilitySpecificData(builder, isis_data)
 
     data = EventMessage.EventMessageEnd(builder)
-    builder.Finish(data)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(data, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())

--- a/streaming_data_types/finished_writing_wrdn.py
+++ b/streaming_data_types/finished_writing_wrdn.py
@@ -17,6 +17,7 @@ def serialise_wrdn(
     message: Optional[str] = None,
 ) -> bytes:
     builder = flatbuffers.Builder(500)
+    builder.ForceDefaults(True)
 
     service_id_offset = builder.CreateString(service_id)
     job_id_offset = builder.CreateString(job_id)
@@ -38,12 +39,9 @@ def serialise_wrdn(
         FinishedWriting.FinishedWritingAddMessage(builder, message_offset)
 
     finished_writing_message = FinishedWriting.FinishedWritingEnd(builder)
-    builder.Finish(finished_writing_message)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(finished_writing_message, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 WritingFinished = NamedTuple(

--- a/streaming_data_types/forwarder_config_update_rf5k.py
+++ b/streaming_data_types/forwarder_config_update_rf5k.py
@@ -76,6 +76,7 @@ def serialise_rf5k(config_change: UpdateType, streams: List[StreamInfo]) -> byte
     :return:
     """
     builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
 
     if streams:
         # We have to use multiple loops/list comprehensions here because we cannot create strings after we have
@@ -104,9 +105,6 @@ def serialise_rf5k(config_change: UpdateType, streams: List[StreamInfo]) -> byte
         ConfigUpdate.ConfigUpdateAddStreams(builder, streams_offset)
     ConfigUpdate.ConfigUpdateAddConfigChange(builder, config_change)
     data = ConfigUpdate.ConfigUpdateEnd(builder)
-    builder.Finish(data)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(data, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())

--- a/streaming_data_types/histogram_hs00.py
+++ b/streaming_data_types/histogram_hs00.py
@@ -117,6 +117,7 @@ def serialise_hs00(histogram):
     info_offset = None
 
     builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
     if "source" in histogram:
         source_offset = builder.CreateString(histogram["source"])
     if "info" in histogram:
@@ -176,12 +177,9 @@ def serialise_hs00(histogram):
             builder, histogram["last_metadata_timestamp"]
         )
     hist_message = EventHistogram.EventHistogramEnd(builder)
-    builder.Finish(hist_message)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(hist_message, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 def _serialise_array(builder, data_len, data):

--- a/streaming_data_types/logdata_f142.py
+++ b/streaming_data_types/logdata_f142.py
@@ -168,14 +168,14 @@ def _complete_buffer(
             LogData.LogDataAddSeverity(builder, alarm_severity)
 
     log_msg = LogData.LogDataEnd(builder)
-    builder.Finish(log_msg)
-    buff = builder.Output()
-    buff[4:8] = FILE_IDENTIFIER
-    return buff
+
+    builder.Finish(log_msg, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 def _setup_builder(source_name: str) -> Tuple[flatbuffers.Builder, int]:
     builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
     source = builder.CreateString(source_name)
     return builder, source
 

--- a/streaming_data_types/nicos_cache_ns10.py
+++ b/streaming_data_types/nicos_cache_ns10.py
@@ -11,6 +11,7 @@ def serialise_ns10(
     key: str, value: str, time_stamp: float = 0, ttl: float = 0, expired: bool = False
 ):
     builder = flatbuffers.Builder(128)
+    builder.ForceDefaults(True)
 
     value_offset = builder.CreateString(value)
     key_offset = builder.CreateString(key)
@@ -22,13 +23,9 @@ def serialise_ns10(
     CacheEntry.CacheEntryAddTime(builder, time_stamp)
     CacheEntry.CacheEntryAddKey(builder, key_offset)
     cache_entry_message = CacheEntry.CacheEntryEnd(builder)
-    builder.Finish(cache_entry_message)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-
-    return bytes(buffer)
+    builder.Finish(cache_entry_message, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 def deserialise_ns10(buffer):

--- a/streaming_data_types/status_x5f2.py
+++ b/streaming_data_types/status_x5f2.py
@@ -65,6 +65,7 @@ def serialise_x5f2(
     """
 
     builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
 
     software_name = builder.CreateString(software_name)
     software_version = builder.CreateString(software_version)
@@ -84,9 +85,6 @@ def serialise_x5f2(
     Status.StatusAddStatusJson(builder, status_json)
 
     data = Status.StatusEnd(builder)
-    builder.Finish(data)
+    builder.Finish(data, file_identifier=FILE_IDENTIFIER)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    return bytes(builder.Output())

--- a/streaming_data_types/timestamps_tdct.py
+++ b/streaming_data_types/timestamps_tdct.py
@@ -21,7 +21,8 @@ def serialise_tdct(
     timestamps: Union[np.ndarray, List],
     sequence_counter: Optional[int] = None,
 ) -> bytes:
-    builder = flatbuffers.Builder(136)
+    builder = flatbuffers.Builder(1024)
+    builder.ForceDefaults(True)
 
     timestamps = np.atleast_1d(np.array(timestamps)).astype(np.uint64)
 
@@ -38,12 +39,9 @@ def serialise_tdct(
     if sequence_counter is not None:
         timestampAddSequenceCounter(builder, sequence_counter)
     timestamps_message = timestampEnd(builder)
-    builder.Finish(timestamps_message)
 
-    # Generate the output and replace the file_identifier
-    buffer = builder.Output()
-    buffer[4:8] = FILE_IDENTIFIER
-    return bytes(buffer)
+    builder.Finish(timestamps_message, file_identifier=FILE_IDENTIFIER)
+    return bytes(builder.Output())
 
 
 Timestamps = namedtuple("Timestamps", ("name", "timestamps", "sequence_counter"))


### PR DESCRIPTION
# Changes

* The code for "manually" setting the file identifier has been replaced with the "blessed" way of doing this.
* The FlatBuffer-builder has been set to always write the zero (default) value in order to work around a bug in the flatbuffers library.
* Added code for accepting `datetime` objects as timestamps for two serialisers.