### PR TITLE
Improve performance of tdct serialiser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 
 setup(
     name="ess_streaming_data_types",
-    version="0.9.3",
+    version="0.9.4",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/streaming_data_types/timestamps_tdct.py
+++ b/streaming_data_types/timestamps_tdct.py
@@ -4,7 +4,6 @@ from streaming_data_types.fbschemas.timestamps_tdct.timestamp import (
     timestampAddName,
     timestampAddTimestamps,
     timestampAddSequenceCounter,
-    timestampStartTimestampsVector,
     timestampEnd,
 )
 import flatbuffers
@@ -28,10 +27,7 @@ def serialise_tdct(
 
     name_offset = builder.CreateString(name)
 
-    timestampStartTimestampsVector(builder, len(timestamps))
-    for single_value in reversed(timestamps):
-        builder.PrependUint64(single_value)
-    array_offset = builder.EndVector(len(timestamps))
+    array_offset = builder.CreateNumpyVector(timestamps)
 
     timestampStart(builder)
     timestampAddName(builder, name_offset)


### PR DESCRIPTION
Improves serialisation of tdct flatbuffer (with 1500 elements) by two orders of magnitude from 9ms to 85µs.