### PR TITLE
Specify flatbuffers 1.12 needed in install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     license="BSD 2-Clause License",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6.0",
-    install_requires=["flatbuffers", "numpy"],
+    install_requires=["flatbuffers>=1.12", "numpy"],
     extras_require={"dev": ["flake8", "pre-commit", "pytest", "tox"]},
 )


### PR DESCRIPTION
I encountered a problem where this library was updated to 0.9.4 but pip didn't know it needed to update the flatbuffers dependency to 1.12 and it therefore complained that `builder.ForceDefaults` was missing.
Is this the correct way of solving that problem?