### PR TITLE
Conda package

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -107,3 +107,42 @@ After testing installing from test.pypi.org works, push to PyPI:
 twine upload dist/*
 ```
 Finally, create a tag on the GitHub repository with the appropriate name, e.g. `v0.7.0`.
+
+### Build and upload conda package
+
+The conda package is used by ESS DMSC DRAM group for the Scipp library.
+
+#### Steps
+
+You must first have a conda installation, for example `conda` via pip, or [miniconda](https://docs.conda.io/en/latest/miniconda.html).
+
+From the directory of the ess-streaming-data-types repository, build the package with
+```sh
+conda create -c conda-forge -n build_pysdt_package python=3.7
+conda activate build_pysdt_package
+conda install -c conda-forge conda-build
+conda build -c conda-forge ./conda
+```
+
+If you already have an environment to build in then instead of creating a new one you can run
+```sh
+conda activate build_pysdt_package
+conda env update
+conda build -c conda-forge ./conda
+```
+
+To upload the package, first login
+```sh
+anaconda login
+```
+use the ESS-DMSC-ECDC account or personal account linked to ESS-DMSC organisation.
+
+Find the path for the built package using
+```sh
+conda build ./conda --output
+```
+
+Then upload
+```sh
+anaconda upload --user ESS-DMSC /path/to/package
+```

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -111,6 +111,7 @@ Finally, create a tag on the GitHub repository with the appropriate name, e.g. `
 ### Build and upload conda package
 
 The conda package is used by ESS DMSC DRAM group for the Scipp library.
+Please create the release version tag on github before creating the conda package as it gets the version number from the tag.
 
 #### Steps
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: ess-streaming-data-types
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  path: ..
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  noarch: python
+  script: python -m pip install --ignore-installed -vv .
+
+requirements:
+  run:
+    - python-flatbuffers >=1.12
+    - numpy
+    - python >=3.6
+
+about:
+  home: https://github.com/ess-dmsc/python-streaming-data-types
+  summary: Python utilities for handling ESS streamed data
+  license: BSD-2-Clause

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from setuptools import setup, find_packages
+from streaming_data_types._version import version
 
 DESCRIPTION = "Python utilities for handling ESS streamed data"
 
@@ -12,9 +13,6 @@ try:
 except Exception as error:
     print("COULD NOT GET LONG DESC: {}".format(error))
     LONG_DESCRIPTION = DESCRIPTION
-
-# Import version number
-from streaming_data_types.__init__ import __version__ as version
 
 setup(
     name="ess_streaming_data_types",

--- a/streaming_data_types/__init__.py
+++ b/streaming_data_types/__init__.py
@@ -17,10 +17,14 @@ from streaming_data_types.forwarder_config_update_rf5k import (
     serialise_rf5k,
 )
 from streaming_data_types.area_detector_NDAr import deserialise_ndar, serialise_ndar
-from streaming_data_types.sample_environment_senv import deserialise_senv, serialise_senv
+from streaming_data_types.sample_environment_senv import (
+    deserialise_senv,
+    serialise_senv,
+)
 from streaming_data_types.area_detector_ADAr import deserialise_ADAr, serialise_ADAr
+from streaming_data_types._version import version
 
-__version__ = "0.11.0"
+__version__ = version
 
 SERIALISERS = {
     "ev42": serialise_ev42,

--- a/streaming_data_types/_version.py
+++ b/streaming_data_types/_version.py
@@ -1,0 +1,4 @@
+# Version is not directly defined in __init__ because that causes all
+# run time dependencies to become build-time dependencies when it is
+# imported in setup.py
+version = "0.11.0"


### PR DESCRIPTION
Changes:

- Importing `__version__` from `__init__.py` in `setup.py` meant that all runtime dependencies were turned into buildtime dependencies. Unless you happen to already have numpy and flatbuffers installed this causes `setup.py` to fail, and was a hurdle for creating the conda package. I moved version into a separate file to solve the problem.
- Added a conda recipe: `conda/meta.yaml`, it is very simple and uses `setup.py` so should be very little effort to maintain.
- Documented building and uploading the conda package.
