### PR TITLE
Fix conda package

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ source:
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   noarch: python
-  script: python -m pip install --ignore-installed -vv .
+  script: python -m pip install --target={{ environ.get('PREFIX') }}/lib/python/site-packages --ignore-installed --no-deps -vv .
 
 requirements:
   run:
@@ -16,6 +16,10 @@ requirements:
     - numpy
     - python >=3.6
 
+test:
+  imports:
+    - streaming_data_types
+    
 about:
   home: https://github.com/ess-dmsc/python-streaming-data-types
   summary: Python utilities for handling ESS streamed data


### PR DESCRIPTION
Fix install location and ensure that import is tested during conda build.
I've uploaded the fixed package to anaconda and carefully tested it: https://anaconda.org/ESS-DMSC/ess-streaming-data-types/files

If you want to test the package you can do:
```
conda create -n test_pysdts -c conda-forge python=3.7 -y
conda activate test_pysdts
conda install ess-dmsc::ess-streaming-data-types
```
Then try importing and using the library in python as usual.