### PR TITLE
Use np asarray to avoid copies

### DIFF
--- a/streaming_data_types/area_detector_ADAr.py
+++ b/streaming_data_types/area_detector_ADAr.py
@@ -68,7 +68,7 @@ def serialise_ADAr(
         data_type = type_map[data.dtype]
 
     # Build dims
-    dims_offset = builder.CreateNumpyVector(np.array(data.shape))
+    dims_offset = builder.CreateNumpyVector(np.asarray(data.shape))
 
     # Build data
     data_offset = builder.CreateNumpyVector(data.flatten().view(np.uint8))

--- a/streaming_data_types/eventdata_ev42.py
+++ b/streaming_data_types/eventdata_ev42.py
@@ -74,8 +74,8 @@ def serialise_ev42(
 
     source = builder.CreateString(source_name)
 
-    tof_data = builder.CreateNumpyVector(np.array(time_of_flight).astype(np.uint32))
-    det_data = builder.CreateNumpyVector(np.array(detector_id).astype(np.uint32))
+    tof_data = builder.CreateNumpyVector(np.asarray(time_of_flight).astype(np.uint32))
+    det_data = builder.CreateNumpyVector(np.asarray(detector_id).astype(np.uint32))
 
     isis_data = None
     if isis_specific:

--- a/streaming_data_types/run_start_pl72.py
+++ b/streaming_data_types/run_start_pl72.py
@@ -63,10 +63,10 @@ def serialise_pl72(
     # Build detector-spectrum map
     if detector_spectrum_map is not None:
         spectrum_map_offset = builder.CreateNumpyVector(
-            np.array(detector_spectrum_map.spectrum_numbers).astype(np.int32)
+            np.asarray(detector_spectrum_map.spectrum_numbers).astype(np.int32)
         )
         det_id_map_offset = builder.CreateNumpyVector(
-            np.array(detector_spectrum_map.detector_ids).astype(np.int32)
+            np.asarray(detector_spectrum_map.detector_ids).astype(np.int32)
         )
         SpectraDetectorMapping.SpectraDetectorMappingStart(builder)
         SpectraDetectorMapping.SpectraDetectorMappingAddSpectrum(

--- a/streaming_data_types/sample_environment_senv.py
+++ b/streaming_data_types/sample_environment_senv.py
@@ -36,7 +36,7 @@ def serialise_senv(
     builder = flatbuffers.Builder(1024)
 
     if value_timestamps is not None:
-        used_timestamps = np.atleast_1d(np.array(value_timestamps)).astype(np.uint64)
+        used_timestamps = np.atleast_1d(np.asarray(value_timestamps)).astype(np.uint64)
         timestamps_offset = builder.CreateNumpyVector(used_timestamps)
 
     numpy_type_map = {
@@ -50,7 +50,7 @@ def serialise_senv(
         np.dtype("uint64"): ValueUnion.UInt64Array,
     }
 
-    temp_values = np.atleast_1d(np.array(values))
+    temp_values = np.atleast_1d(np.asarray(values))
 
     value_array_offset = builder.CreateNumpyVector(temp_values)
 

--- a/streaming_data_types/timestamps_tdct.py
+++ b/streaming_data_types/timestamps_tdct.py
@@ -22,7 +22,7 @@ def serialise_tdct(
     builder = flatbuffers.Builder(1024)
     builder.ForceDefaults(True)
 
-    timestamps = np.atleast_1d(np.array(timestamps)).astype(np.uint64)
+    timestamps = np.atleast_1d(np.asarray(timestamps)).astype(np.uint64)
 
     name_offset = builder.CreateString(name)
 


### PR DESCRIPTION
Use `np.asarray` instead of `np.array` to avoid making a copy in the case that the argument is already an array.