### PR TITLE
updating black version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-black==21.9b0   # Pinned to match pre-commit config
+black==22.3.0   # Pinned to match pre-commit config
 flake8==4.0.1   # Pinned to match pre-commit config
 isort==5.10.1    # Pinned to match pre-commit configblack
 flake8


### PR DESCRIPTION
The previous version had a bug resulting in the error "ImportError: cannot import name '_unicodefun' from 'click'".
This has been fixed in version 22.3.0.