### PR TITLE
Updated the maxtime for running in windows

### DIFF
--- a/streaming_data_types/area_detector_ADAr.py
+++ b/streaming_data_types/area_detector_ADAr.py
@@ -166,7 +166,7 @@ def deserialise_ADAr(buffer: Union[bytearray, bytes]) -> ADArray:
     ad_array = ADArray.ADArray.GetRootAsADArray(buffer, 0)
     unique_id = ad_array.Id()
     max_time = datetime(
-        year=9000, month=1, day=1, hour=0, minute=0, second=0
+        year=3001, month=1, day=1, hour=0, minute=0, second=0
     ).timestamp()
     used_timestamp = ad_array.Timestamp() / 1e9
     if used_timestamp > max_time:


### PR DESCRIPTION
In windows , if the year parameter of the datetime.datetime class is greater than 3001 , it returns OSError: [Errno 22] Invalid argument for Windows 10 operating system. It works fine in Linux. It could be a bug in the python. Setting the year value for max_time to 3001 will fix this error for windows.