### PR TITLE
Provide SCIPP with a method to know latest schema

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Description of Work
+
+*Add a description of the changes here. The aim is provide information to help the approvers review and approve the PR.*
+
+### Issue
+
+*If there is an associated issue, write 'Closes #XXX'*
+
+### Developer Checklist
+
+- [ ] If there are new schema in this PR I have added them to the list in README.md
+- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
+- [ ] and utils.py
+- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.
+
+## Approval Criteria
+
+This PR should not be merged until Matt Clarke has given their explicit approval in the comments section.

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -34,7 +34,7 @@ def latest_schema(schema_type: str):
     return all_schemas()[schema_type]
 
 
-def all_schemas(return_deprecated: bool=False):
+def all_schemas(return_deprecated: bool = False):
     """
     Returns list of all schemas, with deprecated schemas returning a list rather than a single value
     """
@@ -42,14 +42,14 @@ def all_schemas(return_deprecated: bool=False):
     fbs_identifier = {
         "alarm": "al00",
         "area_detector": "ad00",
-        "array_1d": ["se00", DEPRECATED], # deprecated for sample_environment
+        "array_1d": ["se00", DEPRECATED],  # deprecated for sample_environment
         "dataarray": "da00",
         "epics_connection": "ep01",
         "eventdata": "ev44",
         "finished_writing": "wrdn",
         "forwader": "fc00",
-        "histogram": "hs01", # used by just-bin-it and at non-ESS facilities
-        "json": ["json", DEPRECATED], # only debugging
+        "histogram": "hs01",  # used by just-bin-it and at non-ESS facilities
+        "json": ["json", DEPRECATED],  # only debugging
         "logdata": "f144",
         "nicos_cache": "ns10",
         "run_start": "pl72",

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -34,22 +34,22 @@ def latest_schema(schema_type: str):
     return all_schemas()[schema_type]
 
 
-def all_schemas(return_depracated: bool=False):
+def all_schemas(return_deprecated: bool=False):
     """
-    Returns list of all schemas, with depracated schemas returning a list rather than a single value
+    Returns list of all schemas, with deprecated schemas returning a list rather than a single value
     """
-    DEPRACATED = True
+    DEPRECATED = True
     fbs_identifier = {
         "alarm": "al00",
         "area_detector": "ad00",
-        "array_1d": ["se00", DEPRACATED], # deprecated for sample_environment
+        "array_1d": ["se00", DEPRECATED], # deprecated for sample_environment
         "dataarray": "da00",
         "epics_connection": "ep01",
         "eventdata": "ev44",
         "finished_writing": "wrdn",
         "forwader": "fc00",
         "histogram": "hs01", # used by just-bin-it and at non-ESS facilities
-        "json": ["json", DEPRACATED], # only debugging
+        "json": ["json", DEPRECATED], # only debugging
         "logdata": "f144",
         "nicos_cache": "ns10",
         "run_start": "pl72",
@@ -59,4 +59,4 @@ def all_schemas(return_depracated: bool=False):
         "timestamps": "tdct",
     }
 
-    return {k: v for k, v in fbs_identifier.items() if not isinstance(v, list) or return_depracated}
+    return {k: v for k, v in fbs_identifier.items() if not isinstance(v, list) or return_deprecated}

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -1,3 +1,4 @@
+"""Helper functions for data types"""
 from streaming_data_types.exceptions import ShortBufferException, WrongSchemaException
 
 
@@ -24,3 +25,27 @@ def check_schema_identifier(buffer, expected_identifer: bytes):
         raise WrongSchemaException(
             f"Incorrect schema: expected {expected_identifer} but got {get_schema(buffer)}"
         )
+
+
+def latest_schema(schema_type: str):
+    """
+    Returns the latest schema identifier for that type of schema
+    """
+    fbs_identifier = {
+        "alarm": "al00",
+        "area_detector": "ad00",
+        "dataarray": "da00",
+        "epics_connection": "ep01",
+        "eventdata": "ev44",
+        "finished_writing": "wrdn",
+        "forwader": "fc00",
+        # "histogram": "hs01", # depreceated
+        "logdata": "f144",
+        "nicos_cache": "ns10",
+        "run_start": "pl72",
+        "run_stop": "6s4t",
+        "sample_environment": "senv",
+        "status": "x5f2",
+        "timestamps": "tdct",
+    }
+    return fbs_identifier[schema_type]

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -31,15 +31,24 @@ def latest_schema(schema_type: str):
     """
     Returns the latest schema identifier for that type of schema
     """
+    return all_schemas()[schema_type]
+
+
+def all_schemas():
+    """
+    Returns list of all schemas
+    """
     fbs_identifier = {
         "alarm": "al00",
         "area_detector": "ad00",
+        # "array_1d": "se00", # depreceated for sample_environment
         "dataarray": "da00",
         "epics_connection": "ep01",
         "eventdata": "ev44",
         "finished_writing": "wrdn",
         "forwader": "fc00",
-        # "histogram": "hs01", # depreceated
+        # "histogram": "hs01", # depreceated for dataarray
+        # "json": "json", # only debugging
         "logdata": "f144",
         "nicos_cache": "ns10",
         "run_start": "pl72",
@@ -48,4 +57,4 @@ def latest_schema(schema_type: str):
         "status": "x5f2",
         "timestamps": "tdct",
     }
-    return fbs_identifier[schema_type]
+    return fbs_identifier

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -29,7 +29,7 @@ def check_schema_identifier(buffer, expected_identifer: bytes):
 
 def latest_schema(schema_type: str):
     """
-    Returns the latest schema identifier for that type of schema
+    Returns the latest schema identifier for that type of schema and a deprecated flag if relevant
     """
     return all_schemas()[schema_type]
 

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -34,21 +34,22 @@ def latest_schema(schema_type: str):
     return all_schemas()[schema_type]
 
 
-def all_schemas():
+def all_schemas(return_depracated: bool=False):
     """
-    Returns list of all schemas
+    Returns list of all schemas, with depracated schemas returning a list rather than a single value
     """
+    DEPRACATED = True
     fbs_identifier = {
         "alarm": "al00",
         "area_detector": "ad00",
-        # "array_1d": "se00", # deprecated for sample_environment
+        "array_1d": ["se00", DEPRACATED], # deprecated for sample_environment
         "dataarray": "da00",
         "epics_connection": "ep01",
         "eventdata": "ev44",
         "finished_writing": "wrdn",
         "forwader": "fc00",
-        # "histogram": "hs01", # deprecated for dataarray
-        # "json": "json", # only debugging
+        "histogram": "hs01", # used by just-bin-it and at non-ESS facilities
+        "json": ["json", DEPRACATED], # only debugging
         "logdata": "f144",
         "nicos_cache": "ns10",
         "run_start": "pl72",
@@ -57,4 +58,5 @@ def all_schemas():
         "status": "x5f2",
         "timestamps": "tdct",
     }
-    return fbs_identifier
+
+    return {k: v for k, v in fbs_identifier.items() if not isinstance(v, list) or return_depracated}

--- a/streaming_data_types/utils.py
+++ b/streaming_data_types/utils.py
@@ -41,13 +41,13 @@ def all_schemas():
     fbs_identifier = {
         "alarm": "al00",
         "area_detector": "ad00",
-        # "array_1d": "se00", # depreceated for sample_environment
+        # "array_1d": "se00", # deprecated for sample_environment
         "dataarray": "da00",
         "epics_connection": "ep01",
         "eventdata": "ev44",
         "finished_writing": "wrdn",
         "forwader": "fc00",
-        # "histogram": "hs01", # depreceated for dataarray
+        # "histogram": "hs01", # deprecated for dataarray
         # "json": "json", # only debugging
         "logdata": "f144",
         "nicos_cache": "ns10",


### PR DESCRIPTION
There is potentially breaking changes in SCIPP's workflow if they do not know what is the latest file

There are more technical solutions to return the latest schema, but they are more falliable than a simple one-to-one map.

To ensure utils.py is kept updated a PR template is also added.