### PR TITLE
Remove 2.0 upper pin for numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 flatbuffers
-numpy<2.0.0
+numpy>=1.20

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     license="BSD 2-Clause License",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6.0",
-    install_requires=["flatbuffers", "numpy"],
+    install_requires=["flatbuffers", "numpy>=1.20"],
     extras_require={"dev": ["flake8", "pre-commit", "pytest", "tox"]},
 )

--- a/streaming_data_types/logdata_f142.py
+++ b/streaming_data_types/logdata_f142.py
@@ -490,8 +490,8 @@ def _serialise_value(
 ):
     # We can use a dictionary to map most numpy types to one of the types defined in the flatbuffer schema
     # but we have to handle strings separately as there are many subtypes
-    if np.issubdtype(value.dtype, np.unicode_) or np.issubdtype(
-        value.dtype, np.string_
+    if np.issubdtype(value.dtype, np.str_) or np.issubdtype(
+        value.dtype, np.bytes_
     ):
         string_serialiser(builder, value, source)
     else:
@@ -501,7 +501,7 @@ def _serialise_value(
             # There are a few numpy types we don't try to handle, for example complex numbers
             raise NotImplementedError(
                 f"Cannot serialise data of type {value.dtype}, must use one of "
-                f"{list(_map_scalar_type_to_serialiser.keys()) + [np.unicode_]}"
+                f"{list(_map_scalar_type_to_serialiser.keys()) + [np.str_]}"
             )
 
 
@@ -539,8 +539,8 @@ LogDataInfo = namedtuple(
 
 def _decode_if_scalar_string(value: np.ndarray) -> Union[str, np.ndarray]:
     if value.ndim == 0 and (
-        np.issubdtype(value.dtype, np.unicode_)
-        or np.issubdtype(value.dtype, np.string_)
+        np.issubdtype(value.dtype, np.str_)
+        or np.issubdtype(value.dtype, np.bytes_)
     ):
         return value.item().decode()
     return value


### PR DESCRIPTION
These changes should be enough to remove the breaking changes introduced in numpy 2.0

Numpy 1.XX isn't maintained anymore.